### PR TITLE
Use FileUtils rather than 'ftools' for Ruby 1.9.X support. 

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -2,7 +2,7 @@ require 'thor'
 require 'yaml'
 require 'abbrev'
 require 'base64'
-require 'ftools'
+require 'fileutils'
 require 'json'
 require 'fssm'
 
@@ -86,7 +86,7 @@ module ShopifyTheme
         content = Base64.decode64(asset['attachment'])
       end
 
-      File.makedirs(File.dirname(key))
+      FileUtils.mkdir_p(File.dirname(key))
       File.open(key, "w") {|f| f.write content} if content
     end
 


### PR DESCRIPTION
This gem doesn't work under Ruby 1.9, swapping out ftools for fileutils. 
