### PR TITLE
Fix 'errors_from_response'

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -140,7 +140,9 @@ module ShopifyTheme
     end
 
     def errors_from_response(response)
-      response.parsed_response ? response.parsed_response["errors"].values.join(", ") : ""
+      if response.parsed_response
+        response.parsed_response["errors"] ? response.parsed_response["errors"].values.join(", ") : ""
+      end
     end
   end
 end


### PR DESCRIPTION
I kept getting an error within your errors_from_response method in cli.rb. Looks like shopify may have changed how the 'errors' object within the response isn't always necessarily included.

I'm not really a Shopify expert, and I don't really write Ruby either, but this is how I got it to work.
