### PR TITLE
Only delete remote files when necessary with theme watch command

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -142,7 +142,9 @@ module ShopifyTheme
     end
 
     def errors_from_response(response)
-      response.parsed_response ? response.parsed_response["errors"].values.join(", ") : ""
+      if response.parsed_response
+        response.parsed_response["errors"] ? response.parsed_response["errors"].values.join(", ") : ""
+      end
     end
   end
 end


### PR DESCRIPTION
Because files that are present locally overwrite remote files anyway, it is not necessary to delete all files on every execution of `theme watch`.

Only files that are not present locally are deleted on the remote side. Speeds up the command extraordinarily in projects with tons of assets (-> nearly all projects).

Includes fix from https://github.com/Shopify/shopify_theme/pull/21
