### PR TITLE
Syck is removed in Ruby 2.0

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -1,6 +1,6 @@
 require 'thor'
 require 'yaml'
-YAML::ENGINE.yamler = 'syck'
+YAML::ENGINE.yamler = 'syck' if defined? Syck
 require 'abbrev'
 require 'base64'
 require 'fileutils'


### PR DESCRIPTION
Since Syck is removed in Ruby 2.0, the `YAML::ENGINE.yamler` will only be set to `syck` if Syck is actually available
