### PR TITLE
Add timestamps to watch output

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -119,7 +119,7 @@ module ShopifyTheme
     end
 
     def send_asset(asset, quiet=false)
-      time = Time.new
+      time = Time.now
       data = {:key => asset}
       content = File.read(asset)
       if ShopifyTheme.is_binary_data?(content) || BINARY_EXTENSIONS.include?(File.extname(asset).gsub('.',''))
@@ -136,7 +136,7 @@ module ShopifyTheme
     end
 
     def delete_asset(key, quiet=false)
-      time = Time.new
+      time = Time.now
       if (response = ShopifyTheme.delete_asset(key)).success?
         say("[" + time.strftime(TIMEFORMAT) + "] Removed: #{key}", :green) unless quiet
       else


### PR DESCRIPTION
When updating the same file over and over (typos, pixel nudges, etc.) it was getting confusing to work out if the last output message displayed was for the most recent change.
