### PR TITLE
Fix error handling

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -161,8 +161,17 @@ module ShopifyTheme
     end
 
     def errors_from_response(response)
-      if response.parsed_response
-        response.parsed_response["errors"] ? response.parsed_response["errors"].values.join(", ") : ""
+      return unless response.parsed_response
+
+      errors = response.parsed_response["errors"]
+
+      case errors
+      when NilClass
+        ''
+      when String
+        errors
+      else
+        errors.values.join(", ")
       end
     end
   end


### PR DESCRIPTION
### Problem:

```
$ theme upload
/path/to/gems/shopify_theme-0.0.9/lib/shopify_theme/cli.rb:165:in `errors_from_response': undefined method `values' for #<String:0x007fd5db723f40> (NoMethodError)
```
### Cause:
- I provide incorrect API credentials and then run some command like `theme upload`
- Shopify returns a 401 Forbidden status with JSON response: `{"errors":"[API] Invalid API key or access token (unrecognized login or wrong password)"}`
- `parsed_response["errors"]` is a `String`
- Ruby tries to call `values` on the string
- :boom:
### Solution:

If `parsed_response["errors"]` is a `String`, just return it.
