### PR TITLE
Improve binary asset detection

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -12,7 +12,7 @@ module ShopifyTheme
   class Cli < Thor
     include Thor::Actions
 
-    BINARY_EXTENSIONS = %w(png gif jpg jpeg eot svg ttf woff swf ico)
+    BINARY_EXTENSIONS = %w(png gif jpg jpeg eot svg ttf woff otf swf ico)
     IGNORE = %w(config.yml)
     TIMEFORMAT = "%H:%M:%S"
 


### PR DESCRIPTION
`.otf` is a binary font file that isn't correctly detected by `ShopifyTheme.is_binary_data?`, so this Pull Request adds it to the binary extensions whitelist.

While I was there I noticed that the expensive `ShopifyTheme.is_binary_data?` method was always called regardless of the whitelist, so I figured it makes sense to swap the `if` conditions around so that the whitelist effectively guards that call too.
