### PR TITLE
Corrected the URL in Readme to generate you private application

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ gem install shopify_theme [optional_theme_id]
 
 # Usage
 
-Generate the config file. Go get a valid api_key and password for your store head to https://[your store].myshopify.com/admin/api and generate a private application. Default it adds the main theme, if you want to edit one of your other themes, add the theme_id.
+Generate the config file. Go get a valid api_key and password for your store head to https://[your store].myshopify.com/admin/apps/private and generate a private application. Default it adds the main theme, if you want to edit one of your other themes, add the theme_id.
 
 ````
 theme configure api_key password store_url


### PR DESCRIPTION
The old URL was incorrect and pointed to an outdated Shopify page.
Generate a new private application API key here: /admin/apps/private
