### PR TITLE
fixed send_asset for binary files

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -108,7 +108,7 @@ module ShopifyTheme
         end
         if !options['keep_files']
           removed.each do |filePath|
-            delete_asset(filePath, options['quiet']) if local_assets_list.include?(relative)
+            delete_asset(filePath, options['quiet']) if !local_assets_list.include?(filePath)
           end
         end
       end


### PR DESCRIPTION
This fixes the binary file upload "image is corrupt or invalid" error that still was still occurring with the 0.0.9 master branch of the gem.
