### PR TITLE
Hard locks JSON gem dependency to 1.5.4

### DIFF
--- a/shopify_theme.gemspec
+++ b/shopify_theme.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_dependency("thor", [">= 0.14.4"])
   s.add_dependency("httparty", "~> 0.11")
-  s.add_dependency("json")
+  s.add_dependency("json", "~> 1.5.4")
   s.add_dependency("listen", "~>1.0")
   s.add_dependency("launchy")
 


### PR DESCRIPTION
The more reccent versions of the gem (1.8.1 in our case) has a bug
that caused errors when parsing large attachments (mp4 files).

For review @jduff 

/cc @csaunders 
