### PR TITLE
Ignore directories when sending assets

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -128,7 +128,9 @@ module ShopifyTheme
     end
 
     def local_files
-      Dir.glob(File.join('**', '*'))
+      Dir.glob(File.join('**', '*')).reject do |f|
+        File.directory?(f)
+      end
     end
 
     def download_asset(key)
@@ -148,7 +150,6 @@ module ShopifyTheme
     end
 
     def send_asset(asset, quiet=false)
-      return if File.directory?(asset)
       time = Time.now
       data = {:key => asset}
       content = File.read(asset)


### PR DESCRIPTION
This is a patch for #57 in which we were trying to upload directories that were picked up in the dir globbing.

for review @tylerball @jduff 
