### PR TITLE
Adds extension file that should make usage on windows easier

### DIFF
--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,68 @@
+require 'rubygems'
+require 'rubygems/command'
+require 'rubygems/dependency_installer'
+
+module ShopifyTheme
+  module Ext
+    class PlatformInstaller
+      PLATFORMS_WITH_DEPENDENCIES = [:windows]
+
+      def self.run
+        PlatformInstaller.new.run
+      end
+
+      def initialize
+        begin
+          Gem::Command.build_args = ARGV
+        rescue NoMethodError
+        end
+      end
+
+      def run
+        return unless platform_specific_dependencies?
+        install_platform_dependencies
+        indicate_success
+      end
+
+      private
+
+      def platform_specific_dependencies?
+        PLATFORMS_WITH_DEPENDENCIES.include? determine_platform
+      end
+
+      def determine_platform(platform=RUBY_PLATFORM)
+        if platform =~ /mswin|mingw/i
+          :windows
+        else
+          nil
+        end
+      end
+
+      def install_platform_dependencies
+        installer = Gem::DependencyInstaller.new
+        platform = determine_platform
+        if platform == :windows
+          installer.install "wdm"
+        end
+      rescue => e
+        log_error_and_quit(e)
+      end
+
+      def indicate_success
+        File.open(File.join(File.dirname(__FILE__), "Rakefile"), 'wb') do |f|
+          f.puts "task :default"
+        end
+      end
+
+      def log_error_and_quit(e)
+        puts "Could not install shopify_theme for #{RUBY_PLATFORM}"
+        puts "Create a ticket on https://github.com/shopify/shopify_theme/issues with the following information"
+        puts e.message
+        exit(1)
+      end
+
+    end
+  end
+end
+
+ShopifyTheme::Ext::PlatformInstaller.run

--- a/shopify_theme.gemspec
+++ b/shopify_theme.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest', '>= 5.0.0'
 
+  s.extensions   << 'ext/mkrf_conf.rb'
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
After talking to some people on IRC and getting pointed to a guide on installing platform specific code this is what I came up with.

The alternative is to create another gem called maybe `shopify_theme_windows` or something, but I personally thing that's super ghetto. I'd much rather have us use this approach. There is a concern that people might be installing this as root and it can result in running arbitrary code.

I haven't been able to test this out on a Windows box yet, since I don't have one correctly configured on me right now. I can verify this works tonight or something, when I have access to one.

If this works it'll fix #46 

Please review @maartenvg @jduff 

/cc @autonomatt @Kottmaskinen since this might be relevant to your interests
