### PR TITLE
Use an older HTTParty such that we can install JSON with no problems

### DIFF
--- a/shopify_theme.gemspec
+++ b/shopify_theme.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "shopify_theme"
   s.add_dependency("thor", [">= 0.14.4"])
-  s.add_dependency("httparty", "~> 0.11")
+  s.add_dependency("httparty", "~> 0.10.0")
   s.add_dependency("json", "~> 1.5.4")
   s.add_dependency("listen", "~>2.0")
   s.add_dependency("launchy")


### PR DESCRIPTION
We can move these changes into #68 just want to provide an example diff of what was needed to make installing the theme gem work again.

/cc @byroot 
