### PR TITLE
Initialize instance variables fixes #58

### DIFF
--- a/lib/shopify_theme.rb
+++ b/lib/shopify_theme.rb
@@ -6,6 +6,10 @@ module ShopifyTheme
   TIMER_RESET = 5 * 60 + 5
   PERMIT_LOWER_LIMIT = 10
 
+  @@total_api_calls = nil
+  @@current_api_call_count = nil
+  @@current_timer = nil
+
   def self.test?
     ENV['test']
   end


### PR DESCRIPTION
This should fix all the errors when trying to use all the tasks that were causing uninitialized variable errors. I did some debugging as well and looks like the response is the same with or without these variables initialized when it works. For instance debugging

```
def self.manage_timer(response)
  logger.debug response.headers['x-shopify-shop-api-call-limit'].split('/')
  @@current_api_call_count, @@total_api_calls = response.headers['x-shopify-shop-api-call-limit'].split('/')
  @@current_timer = Time.now if @current_timer.nil?
end
```

Results were:

```
$ theme upload assets/app.css.liquid
DEBUG -- : [1,40]
$ theme replace
DEBUG -- : [1,40]
DEBUG -- : [1,40]
DEBUG -- : [1,40]
DEBUG -- : [1,40]
```
