### PR TITLE
Adds systeminfo that will aid in submitting bug reports for oddities

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -122,6 +122,18 @@ module ShopifyTheme
       puts "exiting...."
     end
 
+    desc "systeminfo", "print out system information and actively loaded libraries for aiding in submitting bug reports"
+    def systeminfo
+      ruby_version = "#{RUBY_VERSION}"
+      ruby_version += "-p#{RUBY_PATCHLEVEL}" if RUBY_PATCHLEVEL
+      puts "Ruby: v#{ruby_version}"
+      puts "Operating System: #{RUBY_PLATFORM}"
+      %w(Thor Listen HTTParty Launchy).each do |lib|
+        require "#{lib.downcase}/version"
+        puts "#{lib}: v" +  Kernel.const_get("#{lib}::VERSION")
+      end
+    end
+
     private
 
     def local_assets_list


### PR DESCRIPTION
It's tricky to know what version of a gem people are using on their systems, this will make it easier for people to provide more details about what system they are using and what libraries have been loaded.

Please review @jduff @maartenvg 

This is to help get more information from #73 so we can perhaps figure out what's going on
