### PR TITLE
Moves over to filewatcher for triggering actions

### DIFF
--- a/shopify_theme.gemspec
+++ b/shopify_theme.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency("thor", [">= 0.14.4"])
   s.add_dependency("httparty", "~> 0.10.0")
   s.add_dependency("json", "~> 1.5.4")
-  s.add_dependency("listen", "~>2.0")
+  s.add_dependency("filewatcher")
   s.add_dependency("launchy")
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
The listen gem has had this issue for a while and
looking into it requires possibly making patches to
the listen library. Switching to filewatcher requires
no changes except for changing to another library.

Looking through the filewatcher code it doesn't appear
to have any OS specific dependencies, so this may even
fix the issue with users needing to install WDM on top
of this gem when using Windows.

This fixes issue #73 

Please review @peterjm @maartenvg 

/cc @supervee @tranhelen @markdunkley 
