### PR TITLE
Added --exclude flag to CLI#download

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -38,8 +38,13 @@ module ShopifyTheme
 
     desc "download FILE", "download the shops current theme assets"
     method_option :quiet, :type => :boolean, :default => false
+    method_option :exclude
     def download(*keys)
       assets = keys.empty? ? ShopifyTheme.asset_list : keys
+
+      if options['exclude']
+        assets = assets.delete_if { |asset| asset =~ Regexp.new(options['exclude']) }
+      end
 
       assets.each do |asset|
         download_asset(asset)


### PR DESCRIPTION
I needed a way to avoid downloading certain assets to save time so I've added an `--exclude` flag to the download command. I have a project right now that has 4000+ blog images in assets after a Wordpress import (which might be a separate problem…), but it is now pretty convenient to exclude those on the fly. Perhaps, it's a good feature to further develop?
