### PR TITLE
Feature/timber integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ theme open
 Bootstrap a new theme with [Timber](http://www.shopify.com/timber)
 
 ```
+# use latest stable
 theme bootstrap api_key password shop_name theme_name
+
+# use latest build
+theme bootstrap api_key password shop_name theme_name master
 ```
 
 # Common Problems

--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -36,13 +36,14 @@ module ShopifyTheme
       create_file('config.yml', config.to_yaml)
     end
 
-    desc "bootstrap API_KEY PASSWORD STORE THEME_NAME", "bootstrap with Timber to shop and configure local directory"
-    def bootstrap(api_key=nil, password=nil, store=nil, theme_name=nil)
+    desc "bootstrap API_KEY PASSWORD STORE THEME_NAME", "bootstrap with Timber to shop and configure local directory. Include master if you'd like to use the latest build for the theme"
+    method_option :master, :type => :boolean, :default => false
+    def bootstrap(api_key=nil, password=nil, store=nil, theme_name=nil, master=nil)
       ShopifyTheme.config = {:api_key => api_key, :password => password, :store => store}
 
       theme_name ||= 'Timber'
       say("Registering #{theme_name} theme on #{store}", :green)
-      theme = ShopifyTheme.upload_timber(theme_name)
+      theme = ShopifyTheme.upload_timber(theme_name, master || false)
       
       say("Creating directory named #{theme_name}", :green)
       empty_directory(theme_name)


### PR DESCRIPTION
This adds a `bootstrap` function that makes it easy for theme designers to start working with the [timber theme](http://shopify.com/timber) in their dev shop.

Please review @maartenvg @costford 

/cc @tranhelen @cshold 
