### PR TITLE
Do not raise NotImplementedError if changed file is not in local_assets_...

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -127,17 +127,16 @@ module ShopifyTheme
       watcher do |filename, event|
         filename = filename.gsub("#{Dir.pwd}/", '')
 
-        if local_assets_list.include?(filename)
-          action = if [:changed, :new].include?(event)
-            :send_asset
-          elsif event == :delete
-            :delete_asset
-          else
-            raise NotImplementedError, "Unknown event -- #{event} -- #{filename}"
-          end
-
-          send(action, filename, options['quiet'])
+        next unless local_assets_list.include?(filename)
+        action = if [:changed, :new].include?(event)
+          :send_asset
+        elsif event == :delete
+          :delete_asset
+        else
+          raise NotImplementedError, "Unknown event -- #{event} -- #{filename}"
         end
+
+        send(action, filename, options['quiet'])
       end
     end
 


### PR DESCRIPTION
If there are changed files excluded via the ignore_files setting the watch method is raising a NotImplementedError. In my opinion this is a bug so i changed the if clause to better behave in such cases. If you confirm this as a bug and not a feature i would be happy if you will merge this.
