### PR TITLE
Closes #113 - i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ theme configure api_key password store_url
 
 Example of config.yml. Notice store has no http or https declaration. You can
 use `:whitelist_files:` to specify files for upload. The `assets/`, `config/`,
-`layout/`, `snippets/` and `templates/` directories are included by default.
+`layout/`, `snippets/`, `templates/` and `locales/`directories are included by
+default.
 
 You can also use `:ignore_files:` to exclude files from getting uploaded, for
 example your `config/settings.html` or other configuration driven items

--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -28,7 +28,7 @@ module ShopifyTheme
     include Thor::Actions
 
     IGNORE = %w(config.yml)
-    DEFAULT_WHITELIST = %w(layout/ assets/ config/ snippets/ templates/)
+    DEFAULT_WHITELIST = %w(layout/ assets/ config/ snippets/ templates/ locales/)
     TIMEFORMAT = "%H:%M:%S"
 
     tasks.keys.abbrev.each do |shortcut, command|

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -35,9 +35,9 @@ module ShopifyTheme
     end
 
     it "should remove assets that are not a part of the white list" do
-      @cli.local_files = ['assets/image.png', 'config.yml', 'layout/theme.liquid']
+      @cli.local_files = ['assets/image.png', 'config.yml', 'layout/theme.liquid', 'locales/en.default.json']
       local_assets_list = @cli.send(:local_assets_list)
-      assert_equal 2, local_assets_list.length
+      assert_equal 3, local_assets_list.length
       assert_equal false, local_assets_list.include?('config.yml')
     end
 


### PR DESCRIPTION
Add `locales` directory to the default whitelist.

I've been playing around with the new i18n theme features and was getting frustrated with manually uploading language files :).
