### PR TITLE
Don't throw exception on non-tracked file chaged

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -169,8 +169,10 @@ module ShopifyTheme
       puts "Watching current folder: #{Dir.pwd}"
       watcher do |filename, event|
         filename = filename.gsub("#{Dir.pwd}/", '')
-
-        action = if [:changed, :new].include?(event) && local_assets_list.include?(filename)
+        
+        next unless local_assets_list.include?(filename)
+        
+        action = if [:changed, :new].include?(event)
           :send_asset
         elsif event == :delete && !options['keep_files']
           :delete_asset


### PR DESCRIPTION
Introduced in #155, fixes #166.

We need to skip files that aren't in the whitelist, not throw an uncaught exception.