### PR TITLE
Fixed Ruby installer link

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ layout: index
 
 The Shopify theme gem is a command line tool that lets you make live changes to themes on your Shopify store. If the command line is scary, check out the [Desktop Theme Editor app](http://apps.shopify.com/desktop-theme-editor).
 
-It will watch your local folders for any changes in your theme (including adding and removing files) and will update your .myshopify.com store to the latest changes. 
+It will watch your local folders for any changes in your theme (including adding and removing files) and will update your .myshopify.com store to the latest changes.
 
 ![Shopify theme gem](https://dl.dropboxusercontent.com/u/669627/terminalreadme.png)
 
@@ -15,9 +15,9 @@ remove via the web inspector in Chrome or Safari.
 
 ### Requirements
 
-This gem works with OS X or Windows with Ruby 1.9. 
+This gem works with OS X or Windows with Ruby 1.9.
 
-First time installing Ruby on windows? Try [Rubyinstaller](http://http://rubyinstaller.org/). 
+First time installing Ruby on windows? Try [Rubyinstaller](http://rubyinstaller.org/).
 
 ## Installation
 


### PR DESCRIPTION
## In [index.md line 20](https://github.com/DanielTamkin/shopify_theme/commit/39763f39a5a76f3fb35a650b3ce29829c4aac953#L20)
Fixed from: `[Rubyinstaller](http://http://rubyinstaller.org/)`
To:  `[Rubyinstaller](http://rubyinstaller.org/)`