### PR TITLE
Create Regex from string to prevent crash in replace #185

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -141,7 +141,7 @@ module ShopifyTheme
         # files present on remote and present locally get overridden anyway
         remote_assets = keys.empty? ? (ShopifyTheme.asset_list - local_assets_list) : keys
         remote_assets.each do |asset|
-          delete_asset(asset, options['quiet']) unless ShopifyTheme.ignore_files.any? { |regex| regex =~ asset }
+          delete_asset(asset, options['quiet']) unless ShopifyTheme.ignore_files.any? { |regex| /#{regex}/ =~ asset }
         end
         local_assets = keys.empty? ? local_assets_list : keys
         local_assets.each do |asset|


### PR DESCRIPTION
This seems to fix #185 for me. I haven't done much Ruby programming recently and am not familiar with the `shopify_theme` codebase, so it definitely needs review.