### PR TITLE
[fix #197] =~ operator to .match

### DIFF
--- a/lib/shopify_theme/cli.rb
+++ b/lib/shopify_theme/cli.rb
@@ -141,7 +141,7 @@ module ShopifyTheme
         # files present on remote and present locally get overridden anyway
         remote_assets = keys.empty? ? (ShopifyTheme.asset_list - local_assets_list) : keys
         remote_assets.each do |asset|
-          delete_asset(asset, options['quiet']) unless ShopifyTheme.ignore_files.any? { |regex| regex =~ asset }
+          delete_asset(asset, options['quiet']) unless ShopifyTheme.ignore_files.any? { |regex| regex.match asset }
         end
         local_assets = keys.empty? ? local_assets_list : keys
         local_assets.each do |asset|


### PR DESCRIPTION
operator was crashing `theme replace` command
fixes issue https://github.com/Shopify/shopify_theme/issues/197
related issue https://github.com/Shopify/shopify_theme/issues/185